### PR TITLE
Use single global mcmc kernel

### DIFF
--- a/numpygeons/numpygeons/bridge.py
+++ b/numpygeons/numpygeons/bridge.py
@@ -14,10 +14,6 @@ from autostep.tempering import trace_from_unconst_samples
 # sampling utilities
 ##############################################################################
 
-# need this only because destructuring dictionaries within Julia is impossible
-def make_kernel_from_model(model, kernel_type, kernel_kwargs):
-    return kernel_type(model, **kernel_kwargs)
-
 # sample from prior
 @partial(jax.jit, static_argnums=(0,))
 def sample_iid(model, model_args, model_kwargs, rng_key):

--- a/src/recorders.jl
+++ b/src/recorders.jl
@@ -99,7 +99,7 @@ numpyro_trace() = NumPyroTrace()
 
 function record_sample!(path, trace_recorder, unconstrained_sample, scan_idx)
     constrained_sample = bridge.sample_extractor(
-        path.model,
+        path.mcmc_kernel.model,
         path.model_args, 
         path.model_kwargs, 
         unconstrained_sample, 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,8 @@ include("setup.jl")
 
 # toy unid example
 model, model_args, model_kwargs = pyimport("numpygeons.toy_examples").toy_unid_example()
-kernel_kwargs = pydict(;selector=pyimport("autostep.selectors").AsymmetricSelector())
-path = NumPyroPath(;model,model_args, model_kwargs,kernel_kwargs)
+mcmc_kernel = pyimport("autostep.autohmc").AutoMALA(model)
+path = NumPyroPath(;mcmc_kernel, model_args, model_kwargs)
 true_logZ = unid_target_exact_logZ(100,50)
 
 # inspect initialization
@@ -78,7 +78,8 @@ end
 
 @testset "8 schools" begin
     model, model_args, model_kwargs = pyimport("numpygeons.toy_examples").eight_schools_example()
-    path = NumPyroPath(;model,model_args, model_kwargs)
+    mcmc_kernel = pyimport("autostep.autohmc").AutoMALA(model)
+    path = NumPyroPath(;mcmc_kernel, model_args, model_kwargs)
     pt = pigeons(
         target = path, 
         n_chains = 3,


### PR DESCRIPTION
Cuts down the compilation time to a minimum -- once per run -- without sacrificing anything.